### PR TITLE
Make the "Tab" key no longer change focus

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -554,6 +554,7 @@ class JSONInput extends Component {
             case 'Tab':
                 this.stopEvent(event);
                 document.execCommand("insertText", false, "  ");
+                this.setUpdateTime();
                 break;
             case 'Backspace' : case 'Delete'     :
             case 'ArrowLeft' : case 'ArrowRight' :

--- a/src/index.js
+++ b/src/index.js
@@ -551,6 +551,10 @@ class JSONInput extends Component {
     onKeyDown(event){
         if('viewOnly' in this.props) if(this.props.viewOnly) this.stopEvent(event);
         switch(event.key){
+            case 'Tab':
+                this.stopEvent(event);
+                document.execCommand("insertText", false, "  ");
+                break;
             case 'Backspace' : case 'Delete'     :
             case 'ArrowLeft' : case 'ArrowRight' :
             case 'ArrowUp'   : case 'ArrowDown'  :


### PR DESCRIPTION
Fixes #42 

The tab key no inserts two spaces instead, and also schedules a format update that will be fired if the editor is idling for some time.

We could consider adding a property in the future to disable this behavior to allow the user to tab through if desired.