### PR TITLE
Error indication improvements

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1,9 +1,17 @@
 {
   "name": "react-json-editor-ajrm-example",
-  "version": "1.6.2",
+  "version": "1.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
+      "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.5.13",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.5.13.tgz",
@@ -5137,9 +5145,12 @@
       }
     },
     "react-json-editor-ajrm": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/react-json-editor-ajrm/-/react-json-editor-ajrm-2.5.2.tgz",
-      "integrity": "sha512-zQbqDWOrzrvPXXjlYV+IfgT4v33HCQHB7j64I+hsSkNgtKfGhCp6N69QaF86fG6ayx9QcBieEBrIeJPabHnEOQ=="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/react-json-editor-ajrm/-/react-json-editor-ajrm-2.5.3.tgz",
+      "integrity": "sha512-pyWjSv6jDobsjcsRGz6PiH+KFzbthJ/IGvsBbixVxUt/ZVUw8uK4zNpcgN/7qtVVO/b5maU35HUD+xD2k44JEQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0-rc.0"
+      }
     },
     "read-pkg": {
       "version": "1.1.0",
@@ -5254,6 +5265,11 @@
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
       "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
       "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regex-not": {
       "version": "1.0.2",

--- a/example/src/sampledata.js
+++ b/example/src/sampledata.js
@@ -9,7 +9,16 @@ const sampleData = {
             date_created : 151208443563,
             date_signed : 151208448055,
             date_approved: 151208471190,
-            answers: ['Yes','No','No','Yes','No']
+            answers: [
+                {
+                    Q1 : true,
+                    Q2 : false
+                },
+                {
+                    Q34 : 'This is an answer',
+                    Q35 : false
+                }
+            ]
         },
         A2: {
             userID: "nancy_mccarty",

--- a/src/index.js
+++ b/src/index.js
@@ -1227,6 +1227,13 @@ class JSONInput extends Component {
                                 break;
                             }
                         }
+                        if('key'===type)
+                        if(followedBySymbol(i,['}',']']))
+                        setError(i,format('Key can only be followed by a colon', {
+                            /**
+                             * options
+                             */
+                        }));
                         if(firstChar==="'") string = '"' + string.slice(1,-1) + '"';
                         else if (firstChar!=='"') string = '"' + string + '"';
                         if('key'===type)

--- a/src/index.js
+++ b/src/index.js
@@ -1229,10 +1229,9 @@ class JSONInput extends Component {
                         }
                         if('key'===type)
                         if(followedBySymbol(i,['}',']']))
-                        setError(i,format('Key can only be followed by a colon', {
-                            /**
-                             * options
-                             */
+                        setError(i,format(locale.invalidToken.typesSequence.permitted, {
+                            firstType : locale.types.key,
+                            secondType : locale.types.colon
                         }));
                         if(firstChar==="'") string = '"' + string.slice(1,-1) + '"';
                         else if (firstChar!=='"') string = '"' + string + '"';

--- a/src/locale/en.js
+++ b/src/locale/en.js
@@ -1,7 +1,21 @@
 export default {
   format: "{reason} at line {line}",
+  types: {
+    colon: "colon",
+    key: "key",
+    value: "value",
+    number: "number",
+    string: "string"
+  },
   invalidToken: {
-    sequence: "'{firstToken}' token cannot be followed by a '{secondToken}' token",
+    sequence: {
+      prohibited: "'{firstToken}' token cannot be followed by a '{secondToken}' token",
+      permitted: "'{firstToken}' token can only be followed by '{secondToken}' token"
+    },
+    typesSequence: {
+      prohibited: "A {firstType} cannot be followed by a {secondType}.",
+      permitted: "A {firstType} can only be followed by a {secondType}."
+    },
     double: "'{token}' token cannot be followed by another '{token}' token",
     whitelist: "'{firstToken}' token can only follow '{secondToken}' token",
     useInstead: "'{badToken}' token is not accepted. Use '{goodToken}' instead",


### PR DESCRIPTION
Added missing validation for braces closing before value for a property has been defined.

This fixes issue https://github.com/AndrewRedican/react-json-editor-ajrm/issues/47.

Also, I have not used the locale for system for this error message (temporarily). 
This small excersize made me realize we may be missing some error cases to be defined, and should be included sooner rather than later since we'd have to add translations as we continue to add error messages.

I would like to have your opinion on this.

On `locale.invalidToken` I think we are missing the following cases:

1. Include a `.sequence` message for types not specfic tokens. (Meaning not wrapped in quotes). For example _"Key can only be followed by a colon"_.
2. `.whitelist` should include _"can only be followed by"_ case

Let me know if you agree. Then we'll add translations in this same pull-request.

