### PR TITLE
Remove all usage of IDs

### DIFF
--- a/example/create-react-app-project/src/index.js
+++ b/example/create-react-app-project/src/index.js
@@ -42,7 +42,6 @@ class App extends Component {
     return (
       <div style={{ maxWidth: "1400px", maxHeight: "100%" }}>
         <JSONInput
-          id="unique_string" // an id is required
           placeholder={sampleData} // data to display
           theme="light_mitsuketa_tribute"
           locale={locale}

--- a/example/webpack-project/src/index.js
+++ b/example/webpack-project/src/index.js
@@ -36,7 +36,6 @@ class App extends Component {
     return (
       <div style={{ maxWidth: "1400px", maxHeight: "100%" }}>
         <JSONInput
-          id="unique_string" // an id is required
           placeholder={sampleData} // data to display
           theme="light_mitsuketa_tribute"
           locale={locale}

--- a/src/index.js
+++ b/src/index.js
@@ -567,7 +567,13 @@ class JSONInput extends Component {
         }
     }
     onPaste(event){
-        if('viewOnly' in this.props) if(this.props.viewOnly) this.stopEvent(event);
+        if (this.props.viewOnly) {
+            this.stopEvent(event);
+        } else {
+            event.preventDefault();
+            var text = event.clipboardData.getData('text/plain');
+            document.execCommand('insertHTML', false, text);
+        }
         this.update();
     }
     onClick(){ 
@@ -585,11 +591,6 @@ class JSONInput extends Component {
         this.showPlaceholder();
     }
     componentDidMount(){
-        this.refContent.addEventListener('paste', e => {
-            e.preventDefault();
-            var text = e.clipboardData.getData('text/plain');
-            document.execCommand('insertHTML', false, text);
-        });
         this.showPlaceholder();
     }
     componentWillUnmount(){

--- a/test/change/index.js
+++ b/test/change/index.js
@@ -6,8 +6,6 @@ function run() {
   test(`Update placeholder property value`, () => {
     let wrapper = mount(
       <JSONInput
-        test
-        id='unique_string'
         locale={locale}
         reset={false}
         placeholder={{ valueToChange : false }}

--- a/test/logic/testSyntaxLogic.js
+++ b/test/logic/testSyntaxLogic.js
@@ -23,7 +23,6 @@ function testSyntaxLogic(language='JS',scope,input,output){
     err.isNotType('output',output,'object');
     err.isUndefined('input',input);
 
-    const uniqueID = 'unique_string';
     let markup; 
 
 
@@ -33,8 +32,6 @@ function testSyntaxLogic(language='JS',scope,input,output){
         const
             wrapper = shallow(
                 <JSONInput
-                    test
-                    id     = {uniqueID}
                     locale = {locale}
                 />,
                 { attachTo: window.domNode }
@@ -72,8 +69,6 @@ function testSyntaxLogic(language='JS',scope,input,output){
         const
             wrapper = shallow(
                 <JSONInput
-                    test
-                    id     = {uniqueID}
                     locale = {locale}
                 />,
                 { attachTo: window.domNode }

--- a/test/render/index.js
+++ b/test/render/index.js
@@ -16,8 +16,6 @@ function run() {
   test(`Basic Component Render`, () => {
     let wrapper = mount(
       <JSONInput
-        test
-        id='unique_string'
         locale={locale}
       />,
       { attachTo: window.domNode }
@@ -28,8 +26,6 @@ function run() {
   test(`All Component Properties Render [1]`, () => {
     let wrapper = mount(
       <JSONInput
-        test
-        id='unique_string'
         locale={locale}
         placeholder={sampleData}
         viewOnly={true}
@@ -61,8 +57,6 @@ function run() {
   test(`All Component Properties Render [2]`, () => {
     let wrapper = mount(
       <JSONInput
-        test
-        id='unique_string'
         locale={locale}
         placeholder={sampleData}
         viewOnly={false}


### PR DESCRIPTION
Related to #62 (last paragraph)
Possibly related to #75

This component currently makes heavy usage of DOM IDs. Almost every node created gets its own ID. This makes it very easy to fetch a specific DOM node using the `document.getElementById` function.

This, however, comes at a price. Since IDs are global they are very slow to add and remove. If we have lots of them(like we do) this will have a measurable performance impact.
Furthermore due to their global nature, the risk of clashes is real. We currently try to avoid clashes to the best of our abilities by prefixing all IDs with a random GUID. This however, makes rehydration of server side rendered content nearly impossible, since the client and the server will both generate a different GUID unless they use the same random number seed.

Since we do not actually use the IDs for anything we can easily remove them and gain a measurable speed boost as well as enable SSR.

I also suspect that this will allow us to simplify our unit testing setup a bit, but I'm still looking into that.