### PR TITLE
Add custom error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The `./examples` folder contains two examples:
 ## Features
 
 1. Write as if you are in a text editor.
-2. Checks for syntax mistakes and provides feedback.
+2. Checks for syntax mistakes and provides feedback; Custom errors can also be overlaid on the editor.
 3. You can customize color palette as you please.
 4. Accepts a javascript object in `placeholder` property to display after component mounts.
 5. For any valid textContent, calculates and makes available in this.state as plain text, markup text, and javascript object.
@@ -94,6 +94,9 @@ The `./examples` folder contains two examples:
 | [onKeyPressUpdate]()          | Send `false` if you would like for component not to automatically update on key press.                                                                                                                                                                                                          | boolean  | Optional  |
 | [waitAfterKeyPress]()         | Amount of milliseconds to wait before re-rendering content after keypress. Value defaults to `1000` when not specified. In other words, component will update if there is no additional keystroke after the last one within 1 second. Less than `100` milliseconds does not makes a difference. |  number  | Optional  |
 | [modifyErrorText]()           | A custom function to modify the component's original warning text. This function will receive a single parameter of type `string` and must equally return a `string`.                                                                                                                           | function | Optional  |
+| [error]()                     | **Contains the following properties:**                                                                                                                                                                                                                                                          |  object  | Optional  |
+| error.[reason]()              | A string containing a custom error messsage                                                                                                                                                                                                                                                     |  string  | Optional  |
+| error.[line]()                | A number indicating the line number related to the custom error message                                                                                                                                                                                                                         |  number  | Optional  |
 | [theme]()                     | Specify which [built-in theme](https://github.com/AndrewRedican/react-json-editor-ajrm/wiki/Built-In-Themes) to use.                                                                                                                                                                            |  string  | Optional  |
 | [colors]()                    | **Contains the following properties:**                                                                                                                                                                                                                                                          |  object  | Optional  |
 | colors.[default]()            | Hex color code for any symbols, like curly `braces`, and `comma`.                                                                                                                                                                                                                               |  string  | Optional  |

--- a/src/index.js
+++ b/src/index.js
@@ -110,13 +110,13 @@ class JSONInput extends Component {
         const 
             id           = this.props.id,
             markupText   = this.state.markupText,
-            error        = this.state.error,
+            error        = this.props.error || this.state.error,
             colors       = this.colors,
             style        = this.style,
             confirmGood  = this.confirmGood,
             totalHeight  = this.totalHeight,
             totalWidth   = this.totalWidth,
-            hasError     = error ? 'token' in error : false;
+            hasError     = !!this.props.error || (error ? 'token' in error : false);
         this.renderCount++;
         return (
             <div
@@ -342,7 +342,7 @@ class JSONInput extends Component {
     renderErrorMessage(){
         const
             locale = this.props.locale || defaultLocale,
-            error  = this.state.error,
+            error  = this.props.error || this.state.error,
             style  = this.style;
         if(!error) return void(0);
         return (
@@ -372,7 +372,8 @@ class JSONInput extends Component {
         const
             colors    = this.colors,
             style     = this.style,
-            errorLine = this.state.error ? this.state.error.line : -1,
+            error     = this.props.error || this.state.error,
+            errorLine = error ? error.line : -1,
             lines     = this.state.lines ? this.state.lines : 1;
         let
             labels    = new Array(lines);

--- a/test/render/index.js
+++ b/test/render/index.js
@@ -84,6 +84,18 @@ function run() {
     );
     expect(wrapper).toMatchSnapshot();
   });
+
+  test(`Custom Error Render`, () => {
+    let wrapper = mount(
+      <JSONInput
+        locale={locale}
+        placeholder={sampleData}
+        error={{reason: "My custom error", line: 5}}
+      />,
+      { attachTo: window.domNode }
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
 }
 
 export default run;


### PR DESCRIPTION
Fixes https://github.com/AndrewRedican/react-json-editor-ajrm/issues/77

New `error`prop used as follows:

```jsx
<JSONInput
    error={{line: 5, reason: "My custom error"}}
    placeholder={sampleData} // data to display
    theme="light_mitsuketa_tribute"
    locale={locale}
/>
```

Renders as follows:

<img width="505" alt="screenshot 2018-12-08 at 14 05 52" src="https://user-images.githubusercontent.com/1915543/49687825-a6b12880-fb00-11e8-83b2-20f38cc7e4c7.png">

Regarding a comment in the original issue:

> being able to return custom errors from e.g. onChange functions

This seemed a bit non-standard, so I elected to allow props `error` to override any errors that are present in state. This means that the caller can take responsibility for doing further (JSONschema) validation if the onChange error is not set, and render an error accordingly by passing the `error` prop.