### PR TITLE
Fix HTML from being stripped from pasted text

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -568,7 +568,7 @@ class JSONInput extends Component {
         } else {
             event.preventDefault();
             var text = event.clipboardData.getData('text/plain');
-            document.execCommand('insertHTML', false, text);
+            document.execCommand('insertText', false, text);
         }
         this.update();
     }


### PR DESCRIPTION
# Description

As described in #34, HTML tags were being stripped from pasted text. This is due to using the `insertHTML()` function to insert the text. Because we were using `insertHTML()`, the browser was attempting to interpret the pasted HTML as markup, and was stripping it out of the JSON.

This PR simply changes to using the `insertText()` function instead so the pasted text is inserted as-is without being interpreted by the browser.

# Testing

Copy text containing HTML markup into a JSON string. Note that tags are no longer stripped.